### PR TITLE
203904-Site-Audit-SERPStat-Help-Domain-category-Dupicate-title-Xamarin.Android

### DIFF
--- a/xamarin-android/Licensing/how-to-generate.md
+++ b/xamarin-android/Licensing/how-to-generate.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Overview of Syncfusion® license generation - Syncfusion®
+title: Overview of Xamarin.Android license generation | Syncfusion
 description: Learn here about how to generate Syncfusion® Xamarin.Android license key for syncfusion® Xamarin.Android application for license validation.
 platform: xamarin.android
 control: Essential Studio<sup>®</sup>

--- a/xamarin-android/Licensing/how-to-register-in-an-application.md
+++ b/xamarin-android/Licensing/how-to-register-in-an-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Overview of Syncfusion® license registration - Syncfusion®
+title: Register license key in Xamain.Android Application | Syncfusion
 description: Learn here about how to register Syncfusion® Xamarin.Android license key for Xamarin.Android application for license validation.
 platform: xamarin.android
 control: Essential Studio<sup>®</sup>


### PR DESCRIPTION
Hi @MallikaRK

|Title|Description|
|--|--|
|Task Category| Site Audit- SERPSTAT Blazor Domain Issue Fixes-Duplicate title
|Content Task Link/Mail Screenshot|![image](https://github.com/user-attachments/assets/8fbf34b3-05d1-43f3-b4ad-53bf44d367ba)|
|UX task| NA|
|Hotfix|https://github.com/syncfusion-content/xamarin.android-docs/pull/668
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/203933/|
|Excel/SharePoint link|



|Changes made|Reason for changes|
|--|--|
|Duplicate Title|According to SEO Title should not be duplicated to one another

Regards,
Mercy A.